### PR TITLE
don't serialze with YAML in tests - fixes test issues

### DIFF
--- a/t/30-authenticate_Basic.t
+++ b/t/30-authenticate_Basic.t
@@ -32,7 +32,6 @@ BEGIN {
     set logger      => "file";
 #   set log         => "core";
     set show_errors => 1;
-    set serializer  => "YAML";
     
     use Dancer2::Plugin::HTTP::Auth::Extensible;
     no warnings 'uninitialized';


### PR DESCRIPTION
30-authenticate_Basic.t was serializing with YAML and newer YAMLs prefix
returned data with ---. Removing serialization makes tests work with
current Dancer2 release and also with new plugin2 branch.
